### PR TITLE
Improve dashboard mobile UX

### DIFF
--- a/dashboard/app/layout.jsx
+++ b/dashboard/app/layout.jsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import "./mobile.css";
 
 export const metadata = {
   title:       "SOVEREIGN-GENESIS | Autonomous AI Treasury",

--- a/dashboard/app/mobile.css
+++ b/dashboard/app/mobile.css
@@ -1,43 +1,30 @@
- /* ── Mobile responsiveness
-
-  ───────────────────────────────────────────────── */                
-
-                 
-
-  @media (max-width: 640px) {                                          
-
-    body {
-
-      font-size: 13px;                                                
-
-    }            
-
-
-
-    .card-glow,                                                        
-
-    .card-glow-blue {
-
-      box-shadow: none;                                                
-
-      border: 1px solid rgba(139, 92, 246, 0.25);                      
-
-    }
-
-                                                                       
-
-    .scanline::after {
-
-      display: none;
-
-    }
-
-                                                                       
-
-    ::-webkit-scrollbar {
-
-      width: 0px;                                                      
-
-    }            
-
+@media (max-width: 640px) {
+  html,
+  body {
+    max-width: 100%;
+    overflow-x: hidden;
   }
+
+  body {
+    font-size: 13px;
+  }
+
+  .card-glow,
+  .card-glow-blue {
+    box-shadow: none;
+    border: 1px solid rgba(139, 92, 246, 0.25);
+  }
+
+  .scanline::after {
+    display: none;
+  }
+
+  .mobile-safe-text {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  ::-webkit-scrollbar {
+    width: 0;
+  }
+}

--- a/dashboard/components/DevLog.jsx
+++ b/dashboard/components/DevLog.jsx
@@ -29,10 +29,10 @@ export default function DevLog() {
   );
 
   return (
-    <div className="card-glow rounded-xl border border-sovereign-800/50 bg-[#0a0a14]/80 p-6 backdrop-blur h-full">
+    <div className="card-glow h-full rounded-xl border border-sovereign-800/50 bg-[#0a0a14]/80 p-4 backdrop-blur sm:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between mb-5">
-        <div className="flex items-center gap-3">
+      <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-3">
           <h2 className="text-lg font-bold tracking-widest uppercase text-sovereign-300">
             Development Log
           </h2>
@@ -49,7 +49,13 @@ export default function DevLog() {
           No bounties yet.
         </div>
       ) : (
-        <div className="overflow-x-auto">
+        <>
+        <div className="space-y-3 sm:hidden">
+          {sorted.map((b) => (
+            <BountyMobileCard key={b.id} bounty={b} />
+          ))}
+        </div>
+        <div className="hidden sm:block">
           <table className="w-full text-sm">
             <thead>
               <tr className="text-left text-xs text-slate-600 uppercase tracking-widest border-b border-slate-800">
@@ -66,8 +72,105 @@ export default function DevLog() {
             </tbody>
           </table>
         </div>
+        </>
       )}
     </div>
+  );
+}
+
+function BountyMobileCard({ bounty }) {
+  const paid = bounty.status === "completed";
+  const hasPaidTo = bounty.paidTo && bounty.paidTo !== "0x0000000000000000000000000000000000000000";
+
+  return (
+    <div className="rounded-lg border border-slate-800/80 bg-slate-950/40 p-3">
+      <a
+        href={bounty.issueUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs font-semibold text-sovereign-400 transition-colors hover:text-sovereign-300 mobile-safe-text"
+      >
+        {bounty.title}
+      </a>
+      <div className="mt-1 text-xs font-mono text-slate-600">#{bounty.id}</div>
+
+      <div className="mt-3 grid grid-cols-2 gap-3 text-xs">
+        <div>
+          <div className="mb-1 text-slate-600 uppercase tracking-wider">Reward</div>
+          <span className="font-mono font-bold text-neon-blue">{bounty.reward}</span>
+          {bounty.volatilityNote && (
+            <span className="mt-1 block text-amber-500" title={bounty.volatilityNote}>
+              adjusted
+            </span>
+          )}
+        </div>
+        <div>
+          <div className="mb-1 text-slate-600 uppercase tracking-wider">Status</div>
+          <StatusBadge status={bounty.status} note={bounty.noPayoutNote} />
+        </div>
+      </div>
+
+      <div className="mt-3 text-xs">
+        <div className="mb-1 text-slate-600 uppercase tracking-wider">Contributor</div>
+        {hasPaidTo ? (
+          <div className="font-mono text-emerald-400 mobile-safe-text">{bounty.paidTo}</div>
+        ) : (
+          <span className="text-slate-600">open</span>
+        )}
+        {hasPaidTo && bounty.txHash && (
+          <a
+            href={`${EXPLORER}/tx/${bounty.txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-1 block font-mono text-slate-600 transition-colors hover:text-sovereign-400 mobile-safe-text"
+          >
+            verify tx →
+          </a>
+        )}
+      </div>
+
+      {paid && !hasPaidTo && (
+        <div className="mt-3 rounded-md border border-emerald-700/40 bg-emerald-900/20 px-2 py-1 text-xs text-emerald-400">
+          Paid
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status, note }) {
+  if (status === "completed") {
+    return (
+      <span className="flex w-fit items-center gap-1 rounded border border-emerald-700/40 bg-emerald-900/30 px-2 py-0.5 text-xs text-emerald-400">
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+        PAID
+      </span>
+    );
+  }
+  if (status === "funded") {
+    return (
+      <span className="flex w-fit items-center gap-1 rounded border border-tezos-700/40 bg-tezos-900/30 px-2 py-0.5 text-xs text-tezos-400">
+        <span className="h-1.5 w-1.5 rounded-full bg-tezos-400 animate-pulse" />
+        FUNDED
+      </span>
+    );
+  }
+  if (status === "no_payout") {
+    return (
+      <span
+        className="flex w-fit items-center gap-1 rounded border border-slate-700/40 bg-slate-900/30 px-2 py-0.5 text-xs text-slate-400"
+        title={note || "Issue resolved without payout"}
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-slate-500" />
+        NO PAYOUT
+      </span>
+    );
+  }
+  return (
+    <span className="flex w-fit items-center gap-1 rounded border border-amber-700/40 bg-amber-900/30 px-2 py-0.5 text-xs text-amber-400">
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse" />
+      OPEN
+    </span>
   );
 }
 

--- a/dashboard/components/Header.jsx
+++ b/dashboard/components/Header.jsx
@@ -30,14 +30,14 @@ export default function Header({ lastUpdated }) {
   };
 
   return (
-    <header className={`relative border-b backdrop-blur-sm px-6 py-4 transition-colors duration-300 ${
+    <header className={`relative border-b backdrop-blur-sm px-4 py-4 sm:px-6 transition-colors duration-300 ${
       isDark 
         ? 'border-sovereign-900/60 bg-[#050509]/90' 
         : 'border-light-border bg-light-card'
     }`}>
       <div className="max-w-7xl mx-auto flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
         {/* Logo / title */}
-        <div className="flex items-center gap-4">
+        <div className="flex min-w-0 items-center gap-3 sm:gap-4">
           <div className="relative">
             <div className={`h-10 w-10 rounded-lg flex items-center justify-center text-lg font-bold shadow-lg transition-colors duration-300 ${
               isDark
@@ -51,22 +51,22 @@ export default function Header({ lastUpdated }) {
                  style={{ borderColor: isDark ? '#050509' : '#ffffff' }} />
           </div>
 
-          <div>
-            <h1 className="text-xl font-bold tracking-widest uppercase">
+          <div className="min-w-0">
+            <h1 className="text-lg font-bold tracking-widest uppercase sm:text-xl mobile-safe-text">
               <span className="text-neon-purple">Sovereign</span>
               <span className={isDark ? 'text-slate-500' : 'text-light-muted'}>-</span>
               <span className="text-neon-blue">Genesis</span>
             </h1>
             <p className={`text-xs tracking-widest ${
               isDark ? 'text-slate-600' : 'text-light-muted'
-            }`}>
+            } mobile-safe-text`}>
               AUTONOMOUS AI TREASURY · TEZOS ETHERLINK
             </p>
           </div>
         </div>
 
         {/* Status bar + Theme Toggle */}
-        <div className="flex items-center gap-4 text-xs">
+        <div className="flex w-full flex-wrap items-center gap-3 text-xs sm:w-auto sm:justify-end sm:gap-4">
           {/* Theme Toggle Button */}
           <button
             onClick={toggleTheme}
@@ -89,11 +89,11 @@ export default function Header({ lastUpdated }) {
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
             <span>Live</span>
           </div>
-          <div className={`h-3 w-px ${isDark ? 'bg-slate-700' : 'bg-light-border'}`} />
+          <div className={`hidden h-3 w-px sm:block ${isDark ? 'bg-slate-700' : 'bg-light-border'}`} />
           <span className={isDark ? 'text-slate-500' : 'text-light-muted'}>
             Updated: <span className={isDark ? 'text-slate-400' : 'text-light-text'}>{time}</span>
           </span>
-          <div className={`h-3 w-px ${isDark ? 'bg-slate-700' : 'bg-light-border'}`} />
+          <div className={`hidden h-3 w-px sm:block ${isDark ? 'bg-slate-700' : 'bg-light-border'}`} />
           <span className="text-sovereign-500">EVM · Chain 127823</span>
         </div>
       </div>

--- a/dashboard/components/OpenBounties.jsx
+++ b/dashboard/components/OpenBounties.jsx
@@ -35,9 +35,9 @@ export default function OpenBounties() {
   return (
     <div className="space-y-6">
       {/* Section header */}
-      <div className="card-glow rounded-xl border border-sovereign-800/50 bg-[#0a0a14]/80 p-6 backdrop-blur">
-        <div className="flex items-center justify-between mb-5">
-          <div className="flex items-center gap-3">
+      <div className="card-glow rounded-xl border border-sovereign-800/50 bg-[#0a0a14]/80 p-4 backdrop-blur sm:p-6">
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             <h2 className="text-lg font-bold tracking-widest uppercase text-sovereign-300">
               Open Bounties
             </h2>
@@ -59,14 +59,14 @@ export default function OpenBounties() {
         </div>
 
         {/* How to submit */}
-        <div className="rounded-lg border border-slate-700/50 bg-slate-900/50 p-4 mb-6">
+        <div className="mb-6 rounded-lg border border-slate-700/50 bg-slate-900/50 p-4">
           <h3 className="text-sm font-bold text-slate-300 mb-2">How to Contribute</h3>
           <ol className="text-xs text-slate-400 space-y-1.5 list-decimal list-inside">
             <li>Fork the repository and complete the bounty task</li>
             <li>Open a Pull Request against the main branch</li>
             <li>
               Include your payout wallet in the PR description:
-              <code className="ml-1 bg-slate-800 text-tezos-400 px-1.5 py-0.5 rounded text-xs">
+              <code className="mt-1 inline-block max-w-full rounded bg-slate-800 px-1.5 py-0.5 text-xs text-tezos-400 mobile-safe-text sm:mt-0 sm:ml-1">
                 Wallet: 0xYourAddress
               </code>
             </li>
@@ -96,23 +96,23 @@ function BountyCard({ bounty }) {
   const s = STATUS_STYLE[bounty.status] || STATUS_STYLE.open;
 
   return (
-    <div className="rounded-lg border border-slate-700/50 bg-[#0d0d1a]/80 p-5 flex flex-col gap-3 hover:border-sovereign-700/50 transition-colors">
+    <div className="flex flex-col gap-3 rounded-lg border border-slate-700/50 bg-[#0d0d1a]/80 p-4 transition-colors hover:border-sovereign-700/50 sm:p-5">
       {/* Header row */}
-      <div className="flex items-start justify-between gap-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
         <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-bold text-slate-200 leading-snug">
+          <h3 className="text-sm font-bold leading-snug text-slate-200 mobile-safe-text">
             {bounty.title}
           </h3>
           <span className="text-xs text-slate-600 mt-0.5">#{bounty.id}</span>
         </div>
-        <span className={`shrink-0 flex items-center gap-1.5 text-xs ${s.color} ${s.bg} border px-2 py-0.5 rounded`}>
+        <span className={`flex w-fit shrink-0 items-center gap-1.5 text-xs ${s.color} ${s.bg} border px-2 py-0.5 rounded`}>
           <span className={`h-1.5 w-1.5 rounded-full ${s.dot}`} />
           {s.badge}
         </span>
       </div>
 
       {/* Description */}
-      <p className="text-xs text-slate-400 leading-relaxed line-clamp-3">
+      <p className="text-xs leading-relaxed text-slate-400 line-clamp-3 mobile-safe-text">
         {bounty.description}
       </p>
 
@@ -148,14 +148,14 @@ function BountyCard({ bounty }) {
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <span className="text-xs text-slate-600 uppercase tracking-wider">Paid to:</span>
-            <span className="text-xs font-mono text-emerald-400 truncate">{bounty.paidTo}</span>
+            <span className="text-xs font-mono text-emerald-400 mobile-safe-text">{bounty.paidTo}</span>
           </div>
           {bounty.txHash && (
             <a
               href={`https://shadownet.explorer.etherlink.com/tx/${bounty.txHash}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs font-mono text-slate-500 hover:text-sovereign-400 transition-colors truncate ml-[calc(theme(spacing.2)+3.5rem)] -mt-0.5"
+              className="text-xs font-mono text-slate-500 transition-colors hover:text-sovereign-400 mobile-safe-text sm:ml-[calc(theme(spacing.2)+3.5rem)] sm:-mt-0.5"
             >
               verify tx →
             </a>
@@ -164,7 +164,7 @@ function BountyCard({ bounty }) {
       )}
 
       {/* Actions */}
-      <div className="flex items-center gap-2 mt-auto pt-2 border-t border-slate-800/50">
+      <div className="mt-auto flex flex-col gap-2 border-t border-slate-800/50 pt-2 sm:flex-row sm:items-center">
         <a
           href={bounty.repoUrl}
           target="_blank"

--- a/dashboard/components/TreasuryFeed.jsx
+++ b/dashboard/components/TreasuryFeed.jsx
@@ -14,9 +14,9 @@ const EVENT_META = {
 
 export default function TreasuryFeed({ events = [], isLoading }) {
   return (
-    <div className="card-glow rounded-xl border border-sovereign-800/50 bg-[#0a0a14]/80 p-6 backdrop-blur h-full">
+    <div className="card-glow h-full rounded-xl border border-sovereign-800/50 bg-[#0a0a14]/80 p-4 backdrop-blur sm:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between mb-5">
+      <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h2 className="text-lg font-bold tracking-widest uppercase text-sovereign-300">
           Treasury Activity
         </h2>
@@ -50,8 +50,8 @@ function EventRow({ event }) {
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        <div className="flex items-center justify-between gap-2">
-          <span className={`text-sm font-bold ${meta.color}`}>{meta.label}</span>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className={`text-sm font-bold ${meta.color} mobile-safe-text`}>{meta.label}</span>
           {event.blockNumber && (
             <span className="text-xs text-slate-600">#{event.blockNumber}</span>
           )}
@@ -62,7 +62,7 @@ function EventRow({ event }) {
           {Object.entries(args).map(([k, v]) => (
             <div key={k} className="flex gap-2">
               <span className="text-slate-600 shrink-0">{k}:</span>
-              <span className="truncate font-mono">
+              <span className="font-mono mobile-safe-text">
                 {typeof v === "object" && v !== null ? (v.hash || JSON.stringify(v)) : String(v)}
               </span>
             </div>
@@ -75,7 +75,7 @@ function EventRow({ event }) {
             href={`https://shadownet.explorer.etherlink.com/tx/${event.txHash}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-1 block text-xs text-sovereign-600 hover:text-sovereign-400 font-mono truncate transition-colors"
+            className="mt-1 block text-xs font-mono text-sovereign-600 transition-colors hover:text-sovereign-400 mobile-safe-text"
           >
             tx: {event.txHash}
           </a>


### PR DESCRIPTION
## Summary
- import the existing mobile stylesheet so mobile-specific rules are applied
- make the header, bounty cards, treasury feed, and action controls wrap cleanly on small screens
- replace the mobile Development Log table with stacked cards to avoid horizontal scrolling and improve legibility

## Verification
- `git diff --check`
- `yarn build` from `dashboard/` passed

/claim #16
Wallet: 0xCE6968a8c19b22523f6E28E24d4c16D4f02c635d